### PR TITLE
printing response data

### DIFF
--- a/Client/ApiClient.cs
+++ b/Client/ApiClient.cs
@@ -235,19 +235,26 @@ namespace CyberSource.Client
 
             var httpResponseStatusCode = (int)response.StatusCode;
             var httpResponseHeaders = response.Headers;
-            //var httpResponseData = response.Content;
+            var httpResponseData = response.Content;
 
             Console.WriteLine($"\n");
-            Console.WriteLine($"HTTP RESPONSE STATUS CODE: {httpResponseStatusCode}");
+            Console.WriteLine($"RESPONSE STATUS CODE: {httpResponseStatusCode}");
 
             Console.WriteLine($"\n");
-            Console.WriteLine("HTTP RESPONSE HEADERS:-");
+            Console.WriteLine("RESPONSE HEADERS:-");
 
             foreach (var header in httpResponseHeaders)
             {
                 Console.WriteLine(header);
             }
             Console.WriteLine($"\n");
+
+            if (!string.IsNullOrEmpty(httpResponseData))
+            {
+                Console.WriteLine("RESPONSE BODY:-");
+                Console.WriteLine(httpResponseData);
+                Console.WriteLine($"\n");
+            }
 
             return (Object)response;
         }


### PR DESCRIPTION
**Temporary Fix:** 
For few sample codes the parent response object is getting printed, however data is not getting printed as the object deserialization is not taking place correctly.
Therefore printing response data for the user visibility.

**Permanent Fix (in future release):** 
After the introduction of ApiRequest and ApiResponse objects in ApiClient (POC done for C#), the console statements to be removed from ApiClient.